### PR TITLE
Add capability to disable testing for inactive features

### DIFF
--- a/rules/functions
+++ b/rules/functions
@@ -206,3 +206,31 @@ define generate_manifest
         mv $($(1).gz_PATH)/manifest.common.json $($(1).gz_PATH)/manifest.json
     fi
 endef
+
+###############################################################################
+## Switch off feature testing when functionality doesn't include to build
+## Disable some tests from sonic-utilities
+###############################################################################
+define disable_unused_tests
+    if [ $INCLUDE_NTP == n ]; then
+        DISABLED_TESTS+=("not NTP")
+    fi
+
+    if [ $INCLUDE_RADIUS == n ]; then
+        DISABLED_TESTS+=("not RADIUS")
+    fi
+
+    if [ $INCLUDE_SNMP == n ]; then
+        DISABLED_TESTS+=("not SNMP")
+    fi
+
+    # Generate string with disabling tests
+    # E.g: "not NTP and not RADIUS and not SNMP"
+    delimiter=" and "
+    printf -v joined_array "%s${delimiter}" "${DISABLED_TESTS[@]}"
+    joined_array=${joined_array%${delimiter}}
+
+    if test -n "$DISABLED_TESTS"; then
+        export PYTEST_ADDOPTS+="-k \"${joined_array}\" "
+    fi
+endef

--- a/rules/functions
+++ b/rules/functions
@@ -212,25 +212,25 @@ endef
 ## Disable some tests from sonic-utilities
 ###############################################################################
 define disable_unused_tests
-    if [ $INCLUDE_NTP == n ]; then
-        DISABLED_TESTS+=("not NTP")
+    if [ $(INCLUDE_NTP) == n ]; then
+        DISABLED_TESTS+="not NTP"
     fi
 
-    if [ $INCLUDE_RADIUS == n ]; then
-        DISABLED_TESTS+=("not RADIUS")
+    if [ $(INCLUDE_RADIUS) == n ]; then
+        if [[ -v DISABLED_TESTS ]]; then
+            DISABLED_TESTS+=" and "
+        fi
+        DISABLED_TESTS+="not RADIUS"
     fi
 
-    if [ $INCLUDE_SNMP == n ]; then
-        DISABLED_TESTS+=("not SNMP")
+    if [ $(INCLUDE_SNMP) == n ]; then
+        if [[ -v DISABLED_TESTS ]]; then
+            DISABLED_TESTS+=" and "
+        fi
+        DISABLED_TESTS+="not SNMP"
     fi
 
-    # Generate string with disabling tests
-    # E.g: "not NTP and not RADIUS and not SNMP"
-    delimiter=" and "
-    printf -v joined_array "%s${delimiter}" "${DISABLED_TESTS[@]}"
-    joined_array=${joined_array%${delimiter}}
-
-    if test -n "$DISABLED_TESTS"; then
-        export PYTEST_ADDOPTS+="-k \"${joined_array}\" "
+    if [[ -v DISABLED_TESTS ]]; then
+        export PYTEST_ADDOPTS+="-k \"$${DISABLED_TESTS}\" "
     fi
 endef

--- a/slave.mk
+++ b/slave.mk
@@ -794,7 +794,7 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; fi
 		# Use pip instead of later setup.py to install dependencies into user home, but uninstall self
 		pip$($*_PYTHON_VERSION) install . && pip$($*_PYTHON_VERSION) uninstall --yes `python$($*_PYTHON_VERSION) setup.py --name`
-		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
+		if [ ! "$($*_TEST)" = "n" ]; then  $(call disable_unused_tests); python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
 		python$($*_PYTHON_VERSION) setup.py bdist_wheel $(LOG)
 		# clean up
 		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then quilt pop -a -f; [ -d .pc ] && rm -rf .pc; fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

- Unit test in sonic-utilities fails when some feature is disabled. 
  
These tests run on  SONiC image building and on CI.

#### How I did it
Add capability to disable testing for inactive features.

Used the `-k` PyTest command line option to specify an expression that implements a substring match on the test names.
Expression relates to build configuration.
Example:
` -k "not NTP and not RADIUS and not SNMP"
`

#### How to verify it
Build SONiC image with next parameters:

- INCLUDE_RADIUS=n
- INCLUDE_SNMP=n
- INCLUDE_NTP=n
