### PR TITLE
Update frr to 8.4.2

### DIFF
--- a/rules/frr.mk
+++ b/rules/frr.mk
@@ -1,9 +1,9 @@
 # FRRouting (frr) package
 
-FRR_VERSION = 8.2.2
+FRR_VERSION = 8.4.2
 FRR_SUBVERSION = 0
-FRR_BRANCH = frr/8.2
-FRR_TAG = frr-8.2.2
+FRR_BRANCH = frr/8.4
+FRR_TAG = frr-8.4.2
 export FRR_VERSION FRR_SUBVERSION FRR_BRANCH FRR_TAG
 
 


### PR DESCRIPTION
#### Why I did it
Vulnerability in 8.2.2 

#### How I did it
replaced FRR setting

#### How to verify it
check rules file for frr.

#### Which release branch to backport (provide reason below if selected)
- [ x] dev_202205 - vulnerability 


